### PR TITLE
Fix unhandled rejections w/ lazy fetching

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -148,34 +148,54 @@ Cache = (function() {
   };
 
   Cache.prototype.getOrElse = function(rawKey, val, opts, cb) {
-    var handleError, key, ref, refreshValue, verifyFreshness;
+    var handleError, key, ref, refreshValue, resetStaleOrPending, verifyFreshness, writeValue;
     key = this.applyPrefix(rawKey);
     ref = optionalOpts(opts, cb), cb = ref.cb, opts = ref.opts;
     opts = this.prepareOptions(opts);
-    refreshValue = (function(_this) {
-      return function() {
-        var generatedValue;
-        generatedValue = toPromise(val);
+    resetStaleOrPending = (function(_this) {
+      return function(passThroughData) {
+        delete _this.staleOrPending[key];
+        return passThroughData;
+      };
+    })(this);
+    writeValue = (function(_this) {
+      return function(generatedValue) {
         return _this.set(rawKey, generatedValue, opts).then(function(rawValue) {
           var ref1;
-          delete _this.staleOrPending[key];
           return (ref1 = rawValue != null ? rawValue.d : void 0) != null ? ref1 : null;
-        }, function(err) {
-          delete _this.staleOrPending[key];
+        }, function() {
           return generatedValue != null ? generatedValue : null;
         });
       };
     })(this);
+    refreshValue = function() {
+      var refreshed;
+      return refreshed = toPromise(val).then(writeValue).then(resetStaleOrPending, function(err) {
+        resetStaleOrPending();
+        if (refreshed.wasEverReturned) {
+          return Promise.reject(err);
+        } else {
+          return null;
+        }
+      });
+    };
     verifyFreshness = (function(_this) {
       return function(wrappedValue) {
-        var expired, hit, loadingNewValue, ref1;
+        var dataFromCache, expired, hit, loadingNewValue;
         hit = wrappedValue != null;
         expired = isExpired(wrappedValue != null ? wrappedValue.b : void 0);
         loadingNewValue = _this.staleOrPending[key] != null;
+        dataFromCache = wrappedValue != null ? wrappedValue.d : void 0;
         if ((!hit || expired) && !loadingNewValue) {
           _this.staleOrPending[key] = refreshValue();
+          loadingNewValue = true;
         }
-        return (ref1 = wrappedValue != null ? wrappedValue.d : void 0) != null ? ref1 : _this.staleOrPending[key];
+        if ((dataFromCache == null) && loadingNewValue) {
+          _this.staleOrPending[key].wasEverReturned = true;
+          return _this.staleOrPending[key];
+        } else {
+          return dataFromCache;
+        }
       };
     })(this);
     handleError = function(error) {


### PR DESCRIPTION
Previously whenever a stale value was fetched in the background,
a failing fetch lead to a rejected promise that was never properly
handled. The new behavior is:

* Track if a background-fetch-promise was ever returned to a caller
  via `@staleOrPending[key].wasEverReturned`.
* When a background-fetch-promise is rejected, check if anybody
  cares (via `wasEverReturned`). Depending on that either forward
  the error or swallow it silently. The latter is fine because
  cached will just continue returning the last known value.