### PR TITLE
docs: Update memory backend docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cached('myStuff', { backend: {
 ### Memory
 
 Stores all the data in an in-memory object. 
-***Caveat:** `get()` will return a reference to the stored value. Mutating the returned value will affect the value in the cache.*
+*__Caveat:__ `get()` will return a reference to the stored value. Mutating the returned value will affect the value in the cache.*
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ cached('myStuff', { backend: {
 ### Memory
 
 Stores all the data in an in-memory object. 
+***Caveat:** `get()` will return a reference to the stored value. Mutating the returned value will affect the value in the cache.*
 
 #### Example
 


### PR DESCRIPTION
Make it clear that the memory backend returns references to values and not copies of the values in the cache.

Fixes #28 